### PR TITLE
ignore redirects, accept more status codes for successful probes

### DIFF
--- a/httping.go
+++ b/httping.go
@@ -227,8 +227,9 @@ func ping(httpVerb string, url *url.URL, count int, timeout time.Duration, hostH
 				fmt.Printf("connected to %s, %s, seq=%d, httpVerb=%s, httpStatus=%d, bytes=%d, RTT=%.2f ms\n", url, proxyInformation, i, httpVerb, result.StatusCode, bytes, float32(responseTime)/1e6)
 			}
 
-			// Count how many probes are successful, i.e. how many get a 200 HTTP StatusCode - If successful also add the result to a slice "responseTimes"
-			if result.StatusCode == 200 {
+			// Count how many probes are successful, i.e. how many get a 100-399 HTTP StatusCode - If successful also add the result to a slice "responseTimes"
+			// Read more about HTTP status codes: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+			if result.StatusCode >= 100 && result.StatusCode < 400 {
 				successfulProbes++
 				responseTimes = append(responseTimes, float64(responseTime))
 			}

--- a/httping.go
+++ b/httping.go
@@ -57,6 +57,7 @@ func main() {
 	timeoutPtr := flag.Int("timeout", 2000, "Timeout in milliseconds")
 	hostHeaderPtr := flag.String("hostheader", "", "Optional: Host header")
 	jsonResultsPtr := flag.Bool("json", false, "If true, produces output in json format")
+	followRedirectsPtr := flag.Bool("followredirects", false, "If true, follows redirects, which may result in higher RTT")
 	noProxyPtr := flag.Bool("noproxy", false, "If true, ignores system proxy settings")
 
 	flag.Parse()
@@ -65,6 +66,7 @@ func main() {
 	httpVerb := *httpverbPtr
 	jsonResults := *jsonResultsPtr
 	noProxy := *noProxyPtr
+	followRedirects := *followRedirectsPtr
 
 	if jsonResults == false {
 		fmt.Println("\nhttping " + httpingVersion + " - A tool to measure RTT on HTTP/S requests")
@@ -140,10 +142,10 @@ func main() {
 		fmt.Printf("HTTP %s to %s (%s):\n", httpVerb, url.Host, urlStr)
 	}
 
-	ping(httpVerb, url, *countPtr, timeout, hostHeader, jsonResults, noProxy)
+	ping(httpVerb, url, *countPtr, timeout, hostHeader, jsonResults, followRedirects, noProxy)
 }
 
-func ping(httpVerb string, url *url.URL, count int, timeout time.Duration, hostHeader string, jsonResults bool, noProxy bool) {
+func ping(httpVerb string, url *url.URL, count int, timeout time.Duration, hostHeader string, jsonResults bool, followRedirects bool, noProxy bool) {
 	// This function is responsible to send the requests, count the time and show statistics when finished
 
 	// Initialise needed variables
@@ -153,11 +155,22 @@ func ping(httpVerb string, url *url.URL, count int, timeout time.Duration, hostH
 	var responseTimes []float64
 	fBreak := 0
 
-	// Ignore redirects, for more information:
-	// https://stackoverflow.com/a/38150816
+
 	checkRedirectFunc := func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
+
+	if followRedirects {
+		// This is the default behavior which follows redirects
+		checkRedirectFunc = nil
+	} else {
+		// Ignore redirects, for more information:
+		// https://stackoverflow.com/a/38150816
+		checkRedirectFunc = func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+		}
+	}
+
 
 	// Send requests for url, "count" times
 	for i = 1; (count >= i || count < 1) && fBreak == 0; i++ {

--- a/httping.go
+++ b/httping.go
@@ -153,6 +153,12 @@ func ping(httpVerb string, url *url.URL, count int, timeout time.Duration, hostH
 	var responseTimes []float64
 	fBreak := 0
 
+	// Ignore redirects, for more information:
+	// https://stackoverflow.com/a/38150816
+	checkRedirectFunc := func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
 	// Send requests for url, "count" times
 	for i = 1; (count >= i || count < 1) && fBreak == 0; i++ {
 		// More stateless approach, and as part of it,
@@ -175,6 +181,7 @@ func ping(httpVerb string, url *url.URL, count int, timeout time.Duration, hostH
 		client := http.Client{
 			Timeout: timeout,
 			Transport: transport,
+			CheckRedirect: checkRedirectFunc,
 		}
 
 		// Get the request ready - Headers, verb, etc

--- a/httping.go
+++ b/httping.go
@@ -155,11 +155,7 @@ func ping(httpVerb string, url *url.URL, count int, timeout time.Duration, hostH
 	var responseTimes []float64
 	fBreak := 0
 
-
-	checkRedirectFunc := func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
-
+	var checkRedirectFunc func(req *http.Request, via []*http.Request) error
 	if followRedirects {
 		// This is the default behavior which follows redirects
 		checkRedirectFunc = nil
@@ -170,7 +166,6 @@ func ping(httpVerb string, url *url.URL, count int, timeout time.Duration, hostH
 				return http.ErrUseLastResponse
 		}
 	}
-
 
 	// Send requests for url, "count" times
 	for i = 1; (count >= i || count < 1) && fBreak == 0; i++ {


### PR DESCRIPTION

This PR implements the following changes
* Make code ignore redirects ("Basic redirects support")
* Accept wider range of HTTP status codes for successful probes (100-399, instead of just 200)
    * This includes redirects (301, 304 etc). You can read more about HTTP status codes here, https://developer.mozilla.org/en-US/docs/Web/HTTP/Status

## Explanation and testing

I found this nice URL:

> http://tinyurl.com/redirect.php?num=cd77w8b

Which has at least 5 redirects (see: https://wheregoes.com/trace/20243663092/ , but also it later redirects the browser to a real Amazon book)

So I used this command for testing,
```
go run httping.go -url http://tinyurl.com/redirect.php?num=cd77w8b --noproxy -timeout 10000
```

Before changes, I get the following (note the RTT!):

```

C:\Projects\httping>go run httping.go -url http://tinyurl.com/redirect.php?num=cd77w8b --noproxy -timeout 10000

httping 0.10.0 - A tool to measure RTT on HTTP/S requests
Help: httping -h
HTTP GET to tinyurl.com (http://tinyurl.com/redirect.php?num=cd77w8b):
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=1, httpVerb=GET, httpStatus=200, bytes=1493733, RTT=2668.98 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=2, httpVerb=GET, httpStatus=200, bytes=1491572, RTT=2994.94 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=3, httpVerb=GET, httpStatus=200, bytes=1497742, RTT=2350.27 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=4, httpVerb=GET, httpStatus=200, bytes=1512444, RTT=2548.20 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=5, httpVerb=GET, httpStatus=200, bytes=1491741, RTT=2436.96 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=6, httpVerb=GET, httpStatus=200, bytes=1492246, RTT=2508.15 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=7, httpVerb=GET, httpStatus=200, bytes=1490739, RTT=2444.05 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=8, httpVerb=GET, httpStatus=200, bytes=1497833, RTT=2582.10 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=9, httpVerb=GET, httpStatus=200, bytes=1501181, RTT=2445.46 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=10, httpVerb=GET, httpStatus=200, bytes=1487467, RTT=2088.89 ms

Probes sent: 10
Successful responses: 10
% of requests failed: 0
Min response time: 1s
Average response time: 2.50680077s
Median response time: 2.47680555s
Max response time: 2.9949392s

90% of requests were faster than: 2.6689849s
75% of requests were faster than: 2.56515155s
50% of requests were faster than: 2.4454633s
25% of requests were faster than: 2.39361355s

```

After Basic redirects support was added (using code from https://stackoverflow.com/a/38150816 ) , RTT is lowered, but all probes are considered unsuccessful ("failed"),

```

C:\Projects\httping>go run httping.go -url http://tinyurl.com/redirect.php?num=cd77w8b --noproxy -timeout 10000

httping 0.10.0 - A tool to measure RTT on HTTP/S requests
Help: httping -h
HTTP GET to tinyurl.com (http://tinyurl.com/redirect.php?num=cd77w8b):
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=1, httpVerb=GET, httpStatus=302, bytes=1318, RTT=328.70 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=2, httpVerb=GET, httpStatus=302, bytes=1318, RTT=370.14 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=3, httpVerb=GET, httpStatus=302, bytes=1318, RTT=292.39 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=4, httpVerb=GET, httpStatus=302, bytes=1318, RTT=294.75 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=5, httpVerb=GET, httpStatus=302, bytes=1318, RTT=342.98 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=6, httpVerb=GET, httpStatus=302, bytes=1318, RTT=357.57 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=7, httpVerb=GET, httpStatus=302, bytes=1318, RTT=316.48 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=8, httpVerb=GET, httpStatus=302, bytes=1318, RTT=292.10 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=9, httpVerb=GET, httpStatus=302, bytes=1318, RTT=318.66 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=10, httpVerb=GET, httpStatus=302, bytes=1318, RTT=293.35 ms
All probes failed
exit status 1

```

So I made the code Accept wider range of HTTP status codes for successful probes. Result

```

C:\Projects\httping>go run httping.go -url http://tinyurl.com/redirect.php?num=cd77w8b --noproxy -timeout 10000

httping 0.10.0 - A tool to measure RTT on HTTP/S requests
Help: httping -h
HTTP GET to tinyurl.com (http://tinyurl.com/redirect.php?num=cd77w8b):
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=1, httpVerb=GET, httpStatus=302, bytes=1318, RTT=799.52 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=2, httpVerb=GET, httpStatus=302, bytes=1318, RTT=295.63 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=3, httpVerb=GET, httpStatus=302, bytes=1318, RTT=293.24 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=4, httpVerb=GET, httpStatus=302, bytes=1318, RTT=316.40 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=5, httpVerb=GET, httpStatus=302, bytes=1318, RTT=333.22 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=6, httpVerb=GET, httpStatus=302, bytes=1318, RTT=325.85 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=7, httpVerb=GET, httpStatus=302, bytes=1318, RTT=800.55 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=8, httpVerb=GET, httpStatus=302, bytes=1318, RTT=293.58 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=9, httpVerb=GET, httpStatus=302, bytes=1318, RTT=336.80 ms
connected to http://tinyurl.com/redirect.php?num=cd77w8b, proxy=None, seq=10, httpVerb=GET, httpStatus=302, bytes=1318, RTT=292.42 ms

Probes sent: 10
Successful responses: 10
% of requests failed: 0
Min response time: 292.4208ms
Average response time: 408.71985ms
Median response time: 321.125ms
Max response time: 800.5459ms

90% of requests were faster than: 799.5177ms
75% of requests were faster than: 335.01025ms
50% of requests were faster than: 316.3984ms
25% of requests were faster than: 293.4059ms

```

So I think all necessary changes are implemented.

